### PR TITLE
Automatic parameter setting for simple packing

### DIFF
--- a/gribcoder/encoders.py
+++ b/gribcoder/encoders.py
@@ -33,12 +33,15 @@ class SimplePackingEncoder(BaseEncoder):
     n: int
 
     @classmethod
-    def auto_parametrized_from(cls, n: int, data: np.ndarray, scaling="linear"):
+    def auto_parametrized_from(
+        cls, data: np.ndarray, scaling: str = "simple-linear", **kwargs
+    ):
         """Constructs an encoder with parameter sets.
         Currently, only parameter sets for linear scaling are supported.
         """
-        if scaling == "linear":
-            r, d = _get_parameters_linear(n, data)
+        if scaling == "simple-linear":
+            n = kwargs["nbit"]
+            r, d = _get_parameters_simple_linear(data, n)
         else:
             raise RuntimeError("unsupported scaling type")
 
@@ -175,9 +178,9 @@ class SimplePackingEncoder(BaseEncoder):
         return sect_len
 
 
-def _get_parameters_linear(n: int, data: np.ndarray):
+def _get_parameters_simple_linear(data: np.ndarray, nbit: int):
     min = data.min()
-    d = -ceil(np.log10((data.max() - min) / (2**n - 1)))
+    d = -ceil(np.log10((data.max() - min) / (2**nbit - 1)))
     r = min * 10**d
     return (r, d)
 

--- a/gribcoder/encoders.py
+++ b/gribcoder/encoders.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
+from math import ceil
 from typing import BinaryIO
 
 import numpy as np
@@ -176,7 +177,7 @@ class SimplePackingEncoder(BaseEncoder):
 
 def _get_parameters_linear(n: int, data: np.ndarray):
     min = data.min()
-    d = -round(np.log10((data.max() - min) / (2**n - 1)))
+    d = -ceil(np.log10((data.max() - min) / (2**n - 1)))
     r = min * 10**d
     return (r, d)
 

--- a/gribcoder/encoders.py
+++ b/gribcoder/encoders.py
@@ -31,6 +31,18 @@ class SimplePackingEncoder(BaseEncoder):
     d: int
     n: int
 
+    @classmethod
+    def auto_parametrized_from(cls, n: int, data: np.ndarray, scaling="linear"):
+        """Constructs an encoder with parameter sets.
+        Currently, only parameter sets for linear scaling are supported.
+        """
+        if scaling == "linear":
+            r, d = _get_parameters_linear(n, data)
+        else:
+            raise RuntimeError("unsupported scaling type")
+
+        return cls(r, 0, d, n).input(data)
+
     def input(self, data: np.ndarray):  # `-> Self` for Python >=3.11 (PEP 673)
         """Sets input data to be encoded.
 
@@ -160,6 +172,13 @@ class SimplePackingEncoder(BaseEncoder):
         write(f, header)
         write(f, encoded)
         return sect_len
+
+
+def _get_parameters_linear(n: int, data: np.ndarray):
+    min = data.min()
+    d = -round(np.log10((data.max() - min) / (2**n - 1)))
+    r = min * 10**d
+    return (r, d)
 
 
 def create_bitmap(mask: NDArray[Shape["*"], Bool]) -> NDArray[Shape["*"], UInt8]:

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -96,6 +96,99 @@ def test_auto_parametrization_simple_linear(
 
 
 @pytest.mark.parametrize(
+    "input,decimals,expected_r,expected_e,expected_d,expected_n,expected_encoded,"
+    "expected_restored",
+    [
+        (
+            np.arange(256),
+            0,
+            0.0,
+            0,
+            0,
+            8,
+            np.arange(256),
+            np.arange(256),
+        ),
+        (
+            np.arange(256),
+            1,
+            0.0,
+            0,
+            1,
+            16,
+            np.arange(256) * 10,
+            np.arange(256),
+        ),
+        (
+            np.arange(256),
+            3,
+            0.0,
+            0,
+            3,
+            32,
+            np.arange(256) * 1000,
+            np.arange(256),
+        ),
+        (
+            np.arange(256),
+            8,
+            0.0,
+            0,
+            8,
+            64,
+            np.arange(256) * 100_000_000,
+            np.arange(256),
+        ),
+        (
+            np.arange(256),
+            -1,
+            0.0,
+            0,
+            -1,
+            8,
+            np.round(np.arange(256) * 0.1),
+            np.round(np.arange(256), decimals=-1),
+            # np.arange(256),
+        ),
+        (
+            np.ma.MaskedArray(np.arange(256), mask=[0] + [1] * 254 + [0]),
+            0,
+            0.0,
+            0,
+            0,
+            8,
+            np.array([0, 255]),
+            np.array([0, 255]),
+        ),
+    ],
+)
+def test_auto_parametrization_fixed_digit_linear(
+    input,
+    decimals,
+    expected_r,
+    expected_e,
+    expected_d,
+    expected_n,
+    expected_encoded,
+    expected_restored,
+):
+    encoder = SimplePackingEncoder.auto_parametrized_from(
+        input, scaling="fixed-digit-linear", decimals=decimals
+    )
+    actual_encoded, _actual_bitmap = encoder.encode()
+    assert encoder.r == expected_r
+    assert encoder.e == expected_e
+    assert encoder.d == expected_d
+    assert encoder.n == expected_n
+    np.testing.assert_array_equal(actual_encoded, expected_encoded)
+
+    actual_restored = (
+        encoder.r + actual_encoded.astype(float) * 2**encoder.e
+    ) * 10 ** (-encoder.d)
+    np.testing.assert_array_almost_equal(actual_restored, expected_restored, decimal=15)
+
+
+@pytest.mark.parametrize(
     "input,r,e,d,expected_encoded,expected_bitmap",
     [
         (

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -9,6 +9,64 @@ from gribcoder.encoders import create_bitmap
 
 
 @pytest.mark.parametrize(
+    "input,expected_r,expected_e,expected_d,expected_encoded",
+    [
+        (
+            np.arange(256),
+            0.0,
+            0,
+            0,
+            np.arange(256),
+        ),
+        (
+            np.arange(256) + 100,
+            100.0,
+            0,
+            0,
+            np.arange(256),
+        ),
+        (
+            np.arange(256) * -1,
+            -255.0,
+            0,
+            0,
+            np.arange(256)[::-1],
+        ),
+        (
+            np.arange(256) * 100,
+            0.0,
+            0,
+            -2,
+            np.arange(256),
+        ),
+        (
+            (np.arange(256) + 100) / 100,
+            100.0,
+            0,
+            2,
+            np.arange(256),
+        ),
+        (
+            (np.arange(256) - 100) / 100,
+            -100.0,
+            0,
+            2,
+            np.arange(256),
+        ),
+    ],
+)
+def test_auto_parametrization(
+    input, expected_r, expected_e, expected_d, expected_encoded
+):
+    encoder = SimplePackingEncoder.auto_parametrized_from(8, input, scaling="linear")
+    actual_encoded, _actual_bitmap = encoder.encode()
+    assert encoder.r == expected_r
+    assert encoder.e == expected_e
+    assert encoder.d == expected_d
+    np.testing.assert_array_equal(actual_encoded, expected_encoded)
+
+
+@pytest.mark.parametrize(
     "input,r,e,d,expected_encoded,expected_bitmap",
     [
         (

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -77,10 +77,12 @@ from gribcoder.encoders import create_bitmap
         ),
     ],
 )
-def test_auto_parametrization(
+def test_auto_parametrization_simple_linear(
     input, expected_r, expected_e, expected_d, expected_encoded, expected_restored
 ):
-    encoder = SimplePackingEncoder.auto_parametrized_from(8, input, scaling="linear")
+    encoder = SimplePackingEncoder.auto_parametrized_from(
+        input, scaling="simple-linear", nbit=8
+    )
     actual_encoded, _actual_bitmap = encoder.encode()
     assert encoder.r == expected_r
     assert encoder.e == expected_e

--- a/tests/test_encoders.py
+++ b/tests/test_encoders.py
@@ -67,6 +67,14 @@ from gribcoder.encoders import create_bitmap
             np.array([0, 0, 38, 38]),
             np.array([0, 0, 380, 380]),
         ),
+        (
+            np.ma.MaskedArray(np.arange(256), mask=[0] + [1] * 254 + [0]),
+            0.0,
+            0,
+            0,
+            np.array([0, 255]),
+            np.array([0, 255]),
+        ),
     ],
 )
 def test_auto_parametrization(


### PR DESCRIPTION
There are several patterns for determining parameters for simple packing, depending on the application.
In this PR, I will add an API that can automatically set parameters for encoding for two patterns.