### PR TITLE
Fix a bug in error handling in `Grib2MessageWriter`

### DIFF
--- a/gribcoder/context.py
+++ b/gribcoder/context.py
@@ -25,8 +25,9 @@ class Grib2MessageWriter:
         self._write_sect1()
         return self
 
-    def __exit__(self, _exc_type, _exc_val, _exc_tb):
-        self.close()
+    def __exit__(self, exc_type, _exc_val, _exc_tb):
+        if exc_type is None:
+            self.close()
 
     def close(self):
         self._write_sect8()
@@ -92,7 +93,5 @@ class Grib2MessageWriter:
             raise RuntimeError(
                 f"wrong section order: {self._last_sect_no} -> {sect_no}"
             )
-        try:
-            yield
-        finally:
-            self._last_sect_no = sect_no
+        yield
+        self._last_sect_no = sect_no

--- a/gribcoder/context.py
+++ b/gribcoder/context.py
@@ -89,7 +89,9 @@ class Grib2MessageWriter:
         ):
             pass
         else:
-            raise RuntimeError("wrong section order")
+            raise RuntimeError(
+                f"wrong section order: {self._last_sect_no} -> {sect_no}"
+            )
         try:
             yield
         finally:

--- a/gribcoder/encoders.py
+++ b/gribcoder/encoders.py
@@ -50,7 +50,7 @@ class SimplePackingEncoder(BaseEncoder):
             d = kwargs["decimals"]
             r, n = _get_parameters_fixed_digit_linear(data, d)
         else:
-            raise RuntimeError("unsupported scaling type")
+            raise RuntimeError(f"unsupported scaling type: {scaling}")
 
         return cls(r, 0, d, n).input(data)
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -98,7 +98,7 @@ def test_section_order(order, expectation):
                     fake_write_sect(grib2, num, ind, ident, grid, product, encoder)
 
         if e is not None:
-            assert str(e.value) == "wrong section order"
+            assert str(e.value).startswith("wrong section order")
 
 
 class ParityBitSizedGrid(BaseGrid):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -18,11 +18,11 @@ from gribcoder import (
 from gribcoder.message import DTYPE_SECTION_0
 
 
-def fake_write_sect(grib2, sect_num, ind, ident, grid, product, encoder):
+def fake_write_sect(grib2, sect_num, grid, product, encoder):
     if sect_num == 0:
-        grib2._write_sect1(ind)
+        grib2._write_sect0()
     elif sect_num == 1:
-        grib2._write_sect1(ident)
+        grib2._write_sect1()
     elif sect_num == 2:
         grib2._write_sect2()
     elif sect_num == 3:
@@ -96,7 +96,7 @@ def test_section_order(order, expectation):
                 product = EmptyProductDefinition()
                 encoder = EmptyEncoder()
                 for num in order:
-                    fake_write_sect(grib2, num, ind, ident, grid, product, encoder)
+                    fake_write_sect(grib2, num, grid, product, encoder)
 
         if e is not None:
             assert str(e.value).startswith("wrong section order")
@@ -149,7 +149,7 @@ def test_output_message_length(order, expected):
             product = ParityBitSizedProductDefinition()
             encoder = ParityBitSizedEncoder()
             for num in order:
-                fake_write_sect(grib2, num, ind, ident, grid, product, encoder)
+                fake_write_sect(grib2, num, grid, product, encoder)
 
         output = fw.getvalue()
 


### PR DESCRIPTION
This PR fixes a bug that confused users by generating an extra error
when an error occurred in `Grib2MessageWriter`.

Error was like this:

```
Traceback (most recent call last):
  File "/path/to/gribcoder/examples/generation.py", line 74, in generate_grib2
    encoder = gribcoder.SimplePackingEncoder.auto_parametrized_from(
  File "/path/to/gribcoder/gribcoder/encoders.py", line 47, in auto_parametrized_from
    n = kwargs["nbit"]
KeyError: 'nbit'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/path/to/gribcoder/examples/generation.py", line 97, in <module>
    grib2 = generate_grib2(
  File "/path/to/gribcoder/examples/generation.py", line 26, in generate_grib2
    with gribcoder.Grib2MessageWriter(fw, ind, ident) as grib2:
  File "/path/to/gribcoder/gribcoder/context.py", line 29, in __exit__
    self.close()
  File "/path/to/gribcoder/gribcoder/context.py", line 32, in close
    self._write_sect8()
  File "/path/to/gribcoder/gribcoder/context.py", line 75, in _write_sect8
    with self._section_context(8):
  File "/path/to/.rye/py/cpython@3.10.11/install/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/path/to/gribcoder/gribcoder/context.py", line 92, in _section_context
    raise RuntimeError("wrong section order")
RuntimeError: wrong section order
```