### PR TITLE
Simplify product parameter and fixed surfaces part of product definition APIs

### DIFF
--- a/examples/generation.py
+++ b/examples/generation.py
@@ -62,8 +62,8 @@ def generate_grib2(grid_lats, grid_lons, grid_alts, regridded, time):
                         )
                         .horizontal(
                             np.array(
-                                [(101, 0, alt, 0xFF, 0xFF, 0xFFFFFFFF)],
-                                dtype=gribcoder.DTYPE_SECTION_4_HORIZONTAL,
+                                [[(101, 0, alt)], [(0xFF, 0xFF, 0xFFFFFFFF)]],
+                                dtype=gribcoder.DTYPE_SECTION_4_FIXED_SURFACE,
                             )
                         )
                     )

--- a/examples/generation.py
+++ b/examples/generation.py
@@ -61,9 +61,9 @@ def generate_grib2(grid_lats, grid_lons, grid_alts, regridded, time):
                             )
                         )
                         .horizontal(
-                            np.array(
-                                [[(101, 0, alt)], [(0xFF, 0xFF, 0xFFFFFFFF)]],
-                                dtype=gribcoder.DTYPE_SECTION_4_FIXED_SURFACE,
+                            (
+                                gribcoder.FixedSurface(101, 0, alt),
+                                gribcoder.NULL_FIXED_SURFACE,
                             )
                         )
                     )

--- a/examples/generation.py
+++ b/examples/generation.py
@@ -43,9 +43,8 @@ def generate_grib2(grid_lats, grid_lons, grid_alts, regridded, time):
                     product = (
                         gribcoder.ProductDefinitionWithTemplate4_0(0)
                         .parameter(
-                            np.array(
-                                [(elem.parameter_category, elem.parameter_number)],
-                                dtype=gribcoder.DTYPE_SECTION_4_PARAMETER,
+                            gribcoder.ProductParameter(
+                                elem.parameter_category, elem.parameter_number
                             )
                         )
                         .generating_process(

--- a/gribcoder/__init__.py
+++ b/gribcoder/__init__.py
@@ -3,11 +3,12 @@ from .encoders import BaseEncoder, SimplePackingEncoder
 from .grid import DTYPE_SHAPE_OF_THE_EARTH, BaseGrid, LatitudeLongitudeGrid
 from .message import Identification, Indicator
 from .product import (
-    DTYPE_SECTION_4_FIXED_SURFACE,
     DTYPE_SECTION_4_FORECAST_TIME,
     DTYPE_SECTION_4_GENERATING_PROCESS,
     DTYPE_SECTION_4_PARAMETER,
+    NULL_FIXED_SURFACE,
     BaseProductDefinition,
+    FixedSurface,
     ProductDefinitionWithTemplate4_0,
 )
 
@@ -20,10 +21,11 @@ __all__ = [
     "DTYPE_SHAPE_OF_THE_EARTH",
     "BaseGrid",
     "LatitudeLongitudeGrid",
-    "DTYPE_SECTION_4_FIXED_SURFACE",
+    "FixedSurface",
     "DTYPE_SECTION_4_FORECAST_TIME",
     "DTYPE_SECTION_4_GENERATING_PROCESS",
     "DTYPE_SECTION_4_PARAMETER",
+    "NULL_FIXED_SURFACE",
     "BaseProductDefinition",
     "ProductDefinitionWithTemplate4_0",
     "Identification",

--- a/gribcoder/__init__.py
+++ b/gribcoder/__init__.py
@@ -3,9 +3,9 @@ from .encoders import BaseEncoder, SimplePackingEncoder
 from .grid import DTYPE_SHAPE_OF_THE_EARTH, BaseGrid, LatitudeLongitudeGrid
 from .message import Identification, Indicator
 from .product import (
+    DTYPE_SECTION_4_FIXED_SURFACE,
     DTYPE_SECTION_4_FORECAST_TIME,
     DTYPE_SECTION_4_GENERATING_PROCESS,
-    DTYPE_SECTION_4_HORIZONTAL,
     DTYPE_SECTION_4_PARAMETER,
     BaseProductDefinition,
     ProductDefinitionWithTemplate4_0,
@@ -20,9 +20,9 @@ __all__ = [
     "DTYPE_SHAPE_OF_THE_EARTH",
     "BaseGrid",
     "LatitudeLongitudeGrid",
+    "DTYPE_SECTION_4_FIXED_SURFACE",
     "DTYPE_SECTION_4_FORECAST_TIME",
     "DTYPE_SECTION_4_GENERATING_PROCESS",
-    "DTYPE_SECTION_4_HORIZONTAL",
     "DTYPE_SECTION_4_PARAMETER",
     "BaseProductDefinition",
     "ProductDefinitionWithTemplate4_0",

--- a/gribcoder/__init__.py
+++ b/gribcoder/__init__.py
@@ -5,11 +5,11 @@ from .message import Identification, Indicator
 from .product import (
     DTYPE_SECTION_4_FORECAST_TIME,
     DTYPE_SECTION_4_GENERATING_PROCESS,
-    DTYPE_SECTION_4_PARAMETER,
     NULL_FIXED_SURFACE,
     BaseProductDefinition,
     FixedSurface,
     ProductDefinitionWithTemplate4_0,
+    ProductParameter,
 )
 
 __version__ = "0.2.0"
@@ -22,9 +22,9 @@ __all__ = [
     "BaseGrid",
     "LatitudeLongitudeGrid",
     "FixedSurface",
+    "ProductParameter",
     "DTYPE_SECTION_4_FORECAST_TIME",
     "DTYPE_SECTION_4_GENERATING_PROCESS",
-    "DTYPE_SECTION_4_PARAMETER",
     "NULL_FIXED_SURFACE",
     "BaseProductDefinition",
     "ProductDefinitionWithTemplate4_0",

--- a/gribcoder/product.py
+++ b/gribcoder/product.py
@@ -47,9 +47,9 @@ _DTYPE_SECTION_4_FIXED_SURFACE = np.dtype(
 
 
 class FixedSurface(NamedTuple):
-    type_of_fixed_surface: int
-    scale_factor_of_fixed_surface: int
-    scale_value_of_fixed_surface: int
+    type: int
+    scale_factor: int
+    scale_value: int
 
 
 NULL_FIXED_SURFACE = FixedSurface(0xFF, 0xFF, 0xFFFFFFFF)
@@ -101,9 +101,9 @@ class ProductDefinitionWithTemplate4_0:
             if fs is None
             else [
                 FixedSurface(
-                    fs.type_of_fixed_surface,
-                    grib_signed(fs.scale_factor_of_fixed_surface, 1),
-                    fs.scale_value_of_fixed_surface,
+                    fs.type,
+                    grib_signed(fs.scale_factor, 1),
+                    fs.scale_value,
                 )
             ]
             for fs in surfaces

--- a/gribcoder/product.py
+++ b/gribcoder/product.py
@@ -40,10 +40,10 @@ DTYPE_SECTION_4_FORECAST_TIME = np.dtype(
 DTYPE_SECTION_4_HORIZONTAL = np.dtype(
     [
         ("type_of_first_fixed_surface", "u1"),
-        ("scale_factor_of_first_fixed_surface", "u1"),
+        ("scale_factor_of_first_fixed_surface", "u1"),  # grib_signed
         ("scale_value_of_first_fixed_surface", ">u4"),
         ("type_of_second_fixed_surface", "u1"),
-        ("scale_factor_of_second_fixed_surface", "u1"),
+        ("scale_factor_of_second_fixed_surface", "u1"),  # grib_signed
         ("scale_value_of_second_fixed_surface", ">u4"),
     ]
 )

--- a/gribcoder/product.py
+++ b/gribcoder/product.py
@@ -37,14 +37,11 @@ DTYPE_SECTION_4_FORECAST_TIME = np.dtype(
     ]
 )
 
-DTYPE_SECTION_4_HORIZONTAL = np.dtype(
+DTYPE_SECTION_4_FIXED_SURFACE = np.dtype(
     [
-        ("type_of_first_fixed_surface", "u1"),
-        ("scale_factor_of_first_fixed_surface", "u1"),  # grib_signed
-        ("scale_value_of_first_fixed_surface", ">u4"),
-        ("type_of_second_fixed_surface", "u1"),
-        ("scale_factor_of_second_fixed_surface", "u1"),  # grib_signed
-        ("scale_value_of_second_fixed_surface", ">u4"),
+        ("type_of_fixed_surface", "u1"),
+        ("scale_factor_of_fixed_surface", "u1"),  # grib_signed
+        ("scale_value_of_fixed_surface", ">u4"),
     ]
 )
 
@@ -88,9 +85,9 @@ class ProductDefinitionWithTemplate4_0:
         return self
 
     def horizontal(self, values: np.ndarray):  # `-> Self` for Python >=3.11 (PEP 673)
-        if values.dtype != DTYPE_SECTION_4_HORIZONTAL:
+        if values.dtype != DTYPE_SECTION_4_FIXED_SURFACE:
             raise RuntimeError("wrong dtype")
-        if len(values) != 1:
+        if len(values) != 2:
             raise RuntimeError("wrong length")
         self._horizontal = values
         return self
@@ -107,7 +104,7 @@ class ProductDefinitionWithTemplate4_0:
             + DTYPE_SECTION_4_PARAMETER.itemsize
             + DTYPE_SECTION_4_GENERATING_PROCESS.itemsize
             + DTYPE_SECTION_4_FORECAST_TIME.itemsize
-            + DTYPE_SECTION_4_HORIZONTAL.itemsize
+            + DTYPE_SECTION_4_FIXED_SURFACE.itemsize * 2
         )
 
         header = create_sect_header(4, sect_len)

--- a/gribcoder/product.py
+++ b/gribcoder/product.py
@@ -13,7 +13,7 @@ DTYPE_SECTION_4 = np.dtype(
     ]
 )
 
-DTYPE_SECTION_4_PARAMETER = np.dtype(
+_DTYPE_SECTION_4_PARAMETER = np.dtype(
     [
         ("parameter_category", "u1"),
         ("parameter_number", "u1"),
@@ -46,6 +46,11 @@ _DTYPE_SECTION_4_FIXED_SURFACE = np.dtype(
 )
 
 
+class ProductParameter(NamedTuple):
+    category: int
+    number: int
+
+
 class FixedSurface(NamedTuple):
     type: int
     scale_factor: int
@@ -65,12 +70,10 @@ class BaseProductDefinition(ABC):
 class ProductDefinitionWithTemplate4_0:
     nv: int
 
-    def parameter(self, values: np.ndarray):  # `-> Self` for Python >=3.11 (PEP 673)
-        if values.dtype != DTYPE_SECTION_4_PARAMETER:
-            raise RuntimeError("wrong dtype")
-        if len(values) != 1:
-            raise RuntimeError("wrong length")
-        self._parameter = values
+    def parameter(
+        self, param: ProductParameter
+    ):  # `-> Self` for Python >=3.11 (PEP 673)
+        self._parameter = np.array([param], dtype=_DTYPE_SECTION_4_PARAMETER)
         return self
 
     def generating_process(
@@ -125,7 +128,7 @@ class ProductDefinitionWithTemplate4_0:
         sect_len = (
             SECT_HEADER_DTYPE.itemsize
             + DTYPE_SECTION_4.itemsize
-            + DTYPE_SECTION_4_PARAMETER.itemsize
+            + _DTYPE_SECTION_4_PARAMETER.itemsize
             + DTYPE_SECTION_4_GENERATING_PROCESS.itemsize
             + DTYPE_SECTION_4_FORECAST_TIME.itemsize
             + _DTYPE_SECTION_4_FIXED_SURFACE.itemsize * 2

--- a/gribcoder/product.py
+++ b/gribcoder/product.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 from abc import ABC, abstractmethod
 from typing import BinaryIO, NamedTuple, Optional

--- a/gribcoder/product.py
+++ b/gribcoder/product.py
@@ -1,6 +1,6 @@
 import dataclasses
 from abc import ABC, abstractmethod
-from typing import BinaryIO, NamedTuple
+from typing import BinaryIO, NamedTuple, Optional
 
 import numpy as np
 
@@ -97,7 +97,10 @@ class ProductDefinitionWithTemplate4_0:
         return self
 
     def horizontal(
-        self, surfaces: tuple[FixedSurface | None, FixedSurface | None]
+        self,
+        surfaces: tuple[
+            Optional[FixedSurface], Optional[FixedSurface]
+        ],  # PEP 604 (`A | B` syntax) is not supported in Python <3.10
     ):  # `-> Self` for Python >=3.11 (PEP 673)
         surfaces_ = [
             [NULL_FIXED_SURFACE]

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,10 +1,9 @@
 from io import BytesIO
 
-import numpy as np
 import pytest
 
-from gribcoder import DTYPE_SECTION_4_FIXED_SURFACE, ProductDefinitionWithTemplate4_0
-from gribcoder.utils import grib_signed, write
+from gribcoder import NULL_FIXED_SURFACE, FixedSurface, ProductDefinitionWithTemplate4_0
+from gribcoder.utils import write
 
 
 @pytest.mark.parametrize(
@@ -13,13 +12,7 @@ from gribcoder.utils import grib_signed, write
 )
 def test_writing_horizontal(scale, expected_byte):
     product = ProductDefinitionWithTemplate4_0(0).horizontal(
-        np.array(
-            [
-                [(101, grib_signed(scale, 1), 2)],
-                [(0xFF, 0xFF, 0xFFFFFFFF)],
-            ],
-            dtype=DTYPE_SECTION_4_FIXED_SURFACE,
-        )
+        (FixedSurface(101, scale, 2), NULL_FIXED_SURFACE)
     )
 
     with BytesIO() as f:

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,24 +1,18 @@
 from io import BytesIO
 
-import numpy as np
 import pytest
 
 from gribcoder import (
-    DTYPE_SECTION_4_PARAMETER,
     NULL_FIXED_SURFACE,
     FixedSurface,
     ProductDefinitionWithTemplate4_0,
+    ProductParameter,
 )
 from gribcoder.utils import write
 
 
 def test_writing_parameter():
-    product = ProductDefinitionWithTemplate4_0(0).parameter(
-        np.array(
-            [(0, 1)],
-            dtype=DTYPE_SECTION_4_PARAMETER,
-        )
-    )
+    product = ProductDefinitionWithTemplate4_0(0).parameter(ProductParameter(0, 1))
 
     with BytesIO() as f:
         write(f, product._parameter)

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -3,7 +3,7 @@ from io import BytesIO
 import numpy as np
 import pytest
 
-from gribcoder import DTYPE_SECTION_4_HORIZONTAL, ProductDefinitionWithTemplate4_0
+from gribcoder import DTYPE_SECTION_4_FIXED_SURFACE, ProductDefinitionWithTemplate4_0
 from gribcoder.utils import grib_signed, write
 
 
@@ -14,8 +14,11 @@ from gribcoder.utils import grib_signed, write
 def test_writing_horizontal(scale, expected_byte):
     product = ProductDefinitionWithTemplate4_0(0).horizontal(
         np.array(
-            [(101, grib_signed(scale, 1), 2, 0xFF, 0xFF, 0xFFFFFFFF)],
-            dtype=DTYPE_SECTION_4_HORIZONTAL,
+            [
+                [(101, grib_signed(scale, 1), 2)],
+                [(0xFF, 0xFF, 0xFFFFFFFF)],
+            ],
+            dtype=DTYPE_SECTION_4_FIXED_SURFACE,
         )
     )
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,0 +1,27 @@
+from io import BytesIO
+
+import numpy as np
+import pytest
+
+from gribcoder import DTYPE_SECTION_4_HORIZONTAL, ProductDefinitionWithTemplate4_0
+from gribcoder.utils import grib_signed, write
+
+
+@pytest.mark.parametrize(
+    "scale,expected_byte",
+    [(0, b"\x00"), (-3, b"\x83")],
+)
+def test_writing_horizontal(scale, expected_byte):
+    product = ProductDefinitionWithTemplate4_0(0).horizontal(
+        np.array(
+            [(101, grib_signed(scale, 1), 2, 0xFF, 0xFF, 0xFFFFFFFF)],
+            dtype=DTYPE_SECTION_4_HORIZONTAL,
+        )
+    )
+
+    with BytesIO() as f:
+        write(f, product._horizontal)
+        actual = f.getvalue()
+    expected = b"\x65%b\x00\x00\x00\x02\xff\xff\xff\xff\xff\xff" % (expected_byte)
+
+    assert actual == expected

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,9 +1,31 @@
 from io import BytesIO
 
+import numpy as np
 import pytest
 
-from gribcoder import NULL_FIXED_SURFACE, FixedSurface, ProductDefinitionWithTemplate4_0
+from gribcoder import (
+    DTYPE_SECTION_4_PARAMETER,
+    NULL_FIXED_SURFACE,
+    FixedSurface,
+    ProductDefinitionWithTemplate4_0,
+)
 from gribcoder.utils import write
+
+
+def test_writing_parameter():
+    product = ProductDefinitionWithTemplate4_0(0).parameter(
+        np.array(
+            [(0, 1)],
+            dtype=DTYPE_SECTION_4_PARAMETER,
+        )
+    )
+
+    with BytesIO() as f:
+        write(f, product._parameter)
+        actual = f.getvalue()
+    expected = b"\x00\x01"
+
+    assert actual == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR simplifies how to specify product parameters and fixed surfaces.

Originally, to pass these configuration values to `parameter` and `horizontal` methods,
users had to create NumPy arrays of these configuration values using specified dtypes.
The new API allows these configuration values to be passed directly to the methods.